### PR TITLE
Remove RPM plugin to enable building on a dev machine. Ideally we wil…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -365,6 +365,7 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Commented to allow for local builds to succeed. Need some kind of conditional inclusion so local builds don't require RPM
             <plugin>
               <groupId>org.codehaus.mojo</groupId>
                 <artifactId>rpm-maven-plugin</artifactId>
@@ -409,7 +410,7 @@
                 </mappings>
               </configuration>
             </plugin>
-
+            -->
         </plugins>
     </build>
 


### PR DESCRIPTION
…l make this conditional so it will be used when building for AWS, but not when building for local dev.